### PR TITLE
Don't camelCase data-* and aria-* attributes

### DIFF
--- a/src/om_tools/dom.cljx
+++ b/src/om_tools/dom.cljx
@@ -13,12 +13,22 @@
 (defn clj->js [v]
   (JSValue. v))
 
-(defn camel-case [s]
-  (str/replace
-   s #"-(\w)"
-   #(str/upper-case (second %))))
+(defn camel-case
+  "Converts snake-case to camelCase"
+  [s]
+  (str/replace s #"-(\w)" (comp str/upper-case second)))
 
-(defn opt-key-alias [opt]
+(defn opt-key-case
+  "Converts attributes that are snake-case and should be camelCase"
+  [attr]
+  (if (or (< (count attr) 5)
+          (#{"data-" "aria-"} (subs attr 0 5)))
+    attr
+    (camel-case attr)))
+
+(defn opt-key-alias
+  "Converts aliased attributes"
+  [opt]
   (case opt
     :class :className
     :for :htmlFor
@@ -28,7 +38,7 @@
   (-> opt-key
       opt-key-alias
       name
-      camel-case
+      opt-key-case
       keyword))
 
 (defn format-opt-val [opt-val]

--- a/test/om_tools/dom_test.cljs
+++ b/test/om_tools/dom_test.cljs
@@ -40,7 +40,29 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
 
-(deftest class-set
+(deftest camel-case-test
+  (are [expected s] (= expected (dom/camel-case s))
+       "" ""
+       "foo" "foo"
+       "fooBar" "foo-bar"
+       "fooBarBaz" "foo-bar-baz"
+       "fooBarBaz" "fooBarBaz"))
+
+(deftest opt-key-case-test
+  (is (= "acceptCharset" (dom/opt-key-case "accept-charset")))
+  (is (= "httpEquiv" (dom/opt-key-case "http-equiv")))
+
+  (is (= "test" (dom/opt-key-case "test")))
+
+  (testing "data-* attributes not camel-cased"
+    (is (= "data-test"    (dom/opt-key-case "data-test")))
+    (is (= "data-foo-bar" (dom/opt-key-case "data-foo-bar"))))
+
+  (testing "aria-* attributes not camel-cased"
+    (is (= "aria-test"    (dom/opt-key-case "aria-test")))
+    (is (= "aria-foo-bar" (dom/opt-key-case "aria-foo-bar")))))
+
+(deftest class-set-test
   (testing "nil when no truthy values"
     (is (nil? (dom/class-set {})))
     (is (nil? (dom/class-set {"foo" false})))


### PR DESCRIPTION
Before camel-casing an attribute, check if its a data-\* or aria-\* attribute.
These are special cases for React and should retain in their original form.

Fixes #16
