### PR TITLE
Put in full defcomponent example that compiles on vanilla Clojure/Om

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Example of `defcomponent` including schema annotation:
 
 ```clojure
 (ns example
-  (:require
-    [om-tools.core :refer-macros [defcomponent]]
-    [om-tools.dom :include-macros true]))
+    (:require [om.core :as om :include-macros true]
+              [om-tools.core :refer-macros [defcomponent]]
+              [om-tools.dom :as dom :include-macros true]))
 
-(defcomponent counter [data :- {:init number} owner]
+(defcomponent counter [data owner]
   (will-mount [_]
     (om/set-state! owner :n (:init data)))
   (render-state [_ {:keys [n]}]
@@ -111,7 +111,10 @@ Example of `defcomponent` including schema annotation:
         "+")
       (dom/button
         {:on-click #(om/set-state! owner :n (dec n))}
-        "-")))))
+        "-"))))
+
+(om/root counter {:init 5}
+         {:target js/document.body})
 ```
 
 ### `defcomponentk`


### PR DESCRIPTION
Hi, feel free to ignore this if I missed something, but that ":- {:init number}" part on defcomponent doesn't seem to compile on vanilla Clojure/Om, not sure what that's about. Also, since all you need is 3 more lines of code to turn the snippet into a fully formed Om app, it would help to just put that in for people trying to grok your library.
