### PR TITLE
Add missing close bracket to mixin example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Here's how you could reimplement [React's mixin example][react-mixin]:
 ```clojure
 (ns example
   (:require
-    [om-tools.core :refer-macros [defcomponentk]
+    [om-tools.core :refer-macros [defcomponentk]]
     [om-tools.dom :as dom :include-macros true]
     [om-tools.mixin :refer-macros [defmixin]]))
 


### PR DESCRIPTION
Extremely minor change. This prevents the code from working with a copy paste.
