### PR TITLE
Move CLJS Deps -> Provided

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,6 @@
             :distribution :repo}
 
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2202"]
-                 [com.keminglabs/cljx "0.3.1"]
                  [om "0.6.4"]
                  [prismatic/plumbing "0.3.2"]
                  [prismatic/schema "0.2.4"]]
@@ -15,8 +13,10 @@
   :plugins [[com.keminglabs/cljx "0.3.1"]
             [lein-cljsbuild "1.0.3"]
             [com.cemerick/clojurescript.test "0.3.0"]]
-
-  :profiles {:dev {:dependencies [[prismatic/dommy "0.1.2"]]
+  :profiles {:provided
+             {:dependencies [[org.clojure/clojurescript "0.0-2202"]
+                             [com.keminglabs/cljx "0.3.1"]]}
+             :dev {:dependencies [[prismatic/dommy "0.1.2"]]
                    :cljsbuild
                    {:builds
                     [{:id "example/sliders"


### PR DESCRIPTION
CLJX and Clojurescript don't need to resolve as transitive dependencies in downstream projects (especially CLJX, since it's build-only). This marks these deps as transitive.

Let me know what you think about the clojurescript exclude. This means that users need to explicitly include their own version of clojurescript.

They should be doing this anyway, since you really only want CLJS in a dev profile. No need to bring that jar into production CLJ code.
