### PR TITLE
Support DOM attribute parsing at compile & runtime

### DIFF
--- a/src/om_tools/dom.cljx
+++ b/src/om_tools/dom.cljx
@@ -13,6 +13,14 @@
 (defn clj->js [v]
   (JSValue. v))
 
+#+clj
+(defn literal?
+  "Returns true if form is a literal value (number, string, map, etc),
+  otherwise false."
+  [form]
+  (not (or (symbol? form)
+           (list? form))))
+
 (defn camel-case
   "Converts kebab-case to camelCase"
   [s]
@@ -55,7 +63,7 @@
    (format-opts opt-val)
 
    #+clj
-   (symbol? opt-val)
+   (not (literal? opt-val))
    #+clj
    `(format-opts ~opt-val)
 
@@ -65,15 +73,13 @@
 (defn format-opts
   "Returns JavaScript object for React DOM attributes from opts map"
   [opts]
-  (->> opts
-       (clojure.core/map
-        (fn [[k v]] [(format-opt-key k) (format-opt-val v)]))
-       (into {})
-       clj->js))
-
-(defn ^boolean literal? [form]
-  (not (or (symbol? form)
-           (list? form))))
+  (if (map? opts)
+    (->> opts
+         (clojure.core/map
+          (fn [[k v]] [(format-opt-key k) (format-opt-val v)]))
+         (into {})
+         clj->js)
+    opts))
 
 (defn ^boolean possible-coll? [form]
   (or (coll? form)

--- a/test/om_tools/dom_test.cljs
+++ b/test/om_tools/dom_test.cljs
@@ -166,9 +166,13 @@
         (is=el (nth c i) (nth om-c i)))))
 
   (testing "var in opts"
-    (let [style {:background-color "red"}]
-      (is=el (om-dom/div #js {:style #js {:backgroundColor "red"}})
-             (dom/div {:style style}))))
+    (is=el (om-dom/div #js {:style #js {:backgroundColor "red"}})
+           (let [style {:background-color "red"}]
+             (dom/div {:style style})))
+    (is=el (om-dom/div #js {:style #js {:backgroundColor "red"}})
+           (dom/div {:style (merge {:background-color "red"})}))
+    (is=el (om-dom/div #js {:style #js {:backgroundColor "red"}})
+           (dom/div {:style (when true {:background-color "red"})})))
 
   (testing "js values still work"
     (is=el (dom/div #js {} (dom/span #js {}))


### PR DESCRIPTION
This addresses issue where locally bound value isn't properly converted to
React-friendly DOM attribute value because it isn't parsed at runtime.

When formatting DOM attributes at compile time and we run into a symbol, call
the format function at runtime.

Fixes #33
