### PR TITLE
Fix assert-valid-component exception.

### DIFF
--- a/src/om_tools/core.cljx
+++ b/src/om_tools/core.cljx
@@ -142,7 +142,7 @@
   [body]
   (when-let [invalid-form (first (remove valid-component-form? body))]
     (throw (IllegalArgumentException.
-            "Unexpected form in body of component: " invalid-form))))
+            (str "Unexpected form in body of component: " invalid-form)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/test/om_tools/core_test.clj
+++ b/test/om_tools/core_test.clj
@@ -49,7 +49,11 @@
          (macroexpand
           '(om-tools.core/component
             (init-state [this] {:count 0})
-            (render [this] (om.dom/h1 nil (:text data))))))))
+            (render [this] (om.dom/h1 nil (:text data)))))))
+  (is (thrown-with-msg? IllegalArgumentException #"Unexpected form in body of component"
+                        (macroexpand
+                          '(om-tools.core/component
+                             (render (om.dom/h1 nil (:text data))))))))
 
 (deftest separate-component-config-test
   (are [forms out] (= out (om-tools/separate-component-config forms))


### PR DESCRIPTION
I had a devil of a time figuring out what I'd done wrong. Turns out I'd forgotten to give `render` an argument list and the assertion function was throwing an exception while trying to throw an exception. (Yo dawg.) This should take care of that.
