### PR TITLE
Support zero-arg dom methods

### DIFF
--- a/src/om_tools/dom.cljx
+++ b/src/om_tools/dom.cljx
@@ -79,7 +79,8 @@
 
 #+clj
 (defn ^:private gen-om-dom-inline-fn [tag]
-  `(defmacro ~tag [opts# & children#]
+  `(defmacro ~tag [& [opts# & children#]]
+     {:arglists '([opts? & chilren])}
      (let [ctor# '~(el-ctor tag)]
        (if (literal? opts#)
          (let [[opts# children#] (element-args opts# children#)]

--- a/test/om_tools/dom_test.cljs
+++ b/test/om_tools/dom_test.cljs
@@ -79,6 +79,9 @@
   (testing "simple tag"
     (is=el (dom/a "test") (om-dom/a nil "test")))
 
+  (testing "zero args"
+    (is=el (dom/br) (om-dom/br nil)))
+
   (testing "simple opts"
     (is=el (dom/a {:href "/test"} "test")
            (om-dom/a #js {:href "/test"} "test")))


### PR DESCRIPTION
Instead of

``` clj
(dom/br nil)
```

You can do

``` clj
(dom/br)
```

!
