### PR TITLE
Update version to use clojars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ A ClojureScript library of general-purpose tools for building applications with
 
 Leiningen dependency (Clojars):
 
-```clojure
-[prismatic/om-tools "0.3.12"]
-```
+[![Clojars Project](https://img.shields.io/clojars/v/prismatic/om-tools.svg)](https://clojars.org/prismatic/om-tools)
 
 [![Build Status](https://travis-ci.org/plumatic/om-tools.svg?branch=fix-react-0-12-dom)](https://travis-ci.org/plumatic/om-tools)
 


### PR DESCRIPTION
This ensures the latest version is always on the homepage