### PR TITLE
include `select` in list of form-tags

### DIFF
--- a/src/om_tools/dom.cljx
+++ b/src/om_tools/dom.cljx
@@ -92,7 +92,7 @@
       (list? form)))
 
 #+clj
-(def form-tags '[input textarea option])
+(def form-tags '[input textarea option select])
 
 #+clj
 (def all-tags (concat om.dom/tags form-tags))


### PR DESCRIPTION
via https://github.com/omcljs/om/commit/7c1a337e7e9cf9dfb11e11aa7b3858eec0a3465a

Not sure if this is correct but given that the other `form-tags` are specfied where now also `select` is defined it makes sense to me :)